### PR TITLE
Added user_id placeholder

### DIFF
--- a/bot/logic/welcomemessage.go
+++ b/bot/logic/welcomemessage.go
@@ -322,6 +322,9 @@ var substitutions = map[string]PlaceholderSubstitutionFunc{
 	"user": func(ctx *worker.Context, ticket database.Ticket) string {
 		return fmt.Sprintf("<@%d>", ticket.UserId)
 	},
+	"user_id" : func(ctx *worker.Context, ticket database.Ticket) string {
+		return strconv.FormatUint(uint64(ticket.UserId), 10)
+	}
 	"ticket_id": func(ctx *worker.Context, ticket database.Ticket) string {
 		return strconv.Itoa(ticket.Id)
 	},


### PR DESCRIPTION
The `user_id` placeholder automatically inserts the Discord User ID of the person who opened the ticket into embed. This helps in personalizing and making it easier to manage tickets.